### PR TITLE
devops: Prevent frontend image builds on PR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,11 +63,12 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-frontend
           
     - name: Build and push Frontend Docker image
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v6.7.0
       with:
         context: ./docker/nginx/production
         file: ./docker/nginx/production/Dockerfile
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta-frontend.outputs.tags }}
         labels: ${{ steps.meta-frontend.outputs.labels }}
         build-args: |


### PR DESCRIPTION
* Builds the frontend Docker image and pushes it to the registry only on pushes to the main branch as it depends on the main image which is not pushed on PR